### PR TITLE
Add an error when black does not return successfully.

### DIFF
--- a/sublack.py
+++ b/sublack.py
@@ -72,7 +72,8 @@ class Black:
                 cwd=self.popen_cwd,
                 startupinfo=self.popen_startupinfo,
             )
-            if p.returncode == None:
+            p.wait()
+            if p.returncode == 1 or p.returncode == 123:
                 msg = "Black did not run succesfully: please check the console for details."
                 sublime.error_message(msg)
                 print(p.stdout.readlines(), p.stderr.readlines())

--- a/sublack.py
+++ b/sublack.py
@@ -73,7 +73,7 @@ class Black:
                 startupinfo=self.popen_startupinfo,
             )
             p.wait()
-            if p.returncode == 1 or p.returncode == 123:
+            if p.returncode != 0:
                 msg = "Black did not run succesfully: please check the console for details."
                 sublime.error_message(msg)
                 print(p.stdout.readlines(), p.stderr.readlines())

--- a/sublack.py
+++ b/sublack.py
@@ -65,13 +65,17 @@ class Black:
             print("line : ", self.popen_args)
 
         try:
-            subprocess.Popen(
+            p = subprocess.Popen(
                 self.popen_args,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=self.popen_cwd,
                 startupinfo=self.popen_startupinfo,
             )
+            if p.returncode == None:
+                msg = "Black did not run succesfully: please check the console for details."
+                sublime.error_message(msg)
+                print(p.stdout.readlines(), p.stderr.readlines())
 
         except OSError as err:
             # always show error in popup


### PR DESCRIPTION
Somehow my ST3 installation had a different locale from the rest of the system, which was causing black to crash as it tried to load the 'click' library. Sublack failed quietly in this scenario. 

This pull request changes it to throw an error and output the `black` stderr and stdout to the console.