### PR TITLE
Fix click crash when sublime locale isn't set properly

### DIFF
--- a/sublack.py
+++ b/sublack.py
@@ -67,9 +67,15 @@ class Black:
         content = self.view.substr(all_file)
         content = content.encode(encoding)
 
+        # modifying the locale is necessary to keep the click library happy on some systems.
+        env = os.environ.copy()
+        if "LC_ALL" not in env.keys():
+            env["LC_ALL"] = "en_US.UTF-8"
+
         try:
             p = subprocess.Popen(
                 self.cmd,
+                env=env,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,


### PR DESCRIPTION
By explicitly setting LC_ALL we avoid triggering a crash in click (#2). This is necessary because ST3's python interpreter has a weird environment on Mac OS X, which is passed to the black process which uses click.  
