### PR TITLE
Remove trailing commas

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -4,5 +4,5 @@
             "ctrl+alt+f"
         ],
         "command": "black_file"
-    },
+    }
 ]

--- a/sublack.sublime-settings
+++ b/sublack.sublime-settings
@@ -12,7 +12,7 @@
       //debug mode
       // show black log in console
       // errors are always shown
-      "debug": false,
+      "debug": false
 
       // default encoding for never saved file, if not specified un  first 2 lines (pep 263):
       // default is "utf-8". uncomment and change this only if you want override default behaviour.


### PR DESCRIPTION
The latest build of SublimeText2 (Version 2.0.2, Build 2221)
errors out when loading. Removing the trailing commas fixes
the error.