### PR TITLE
Document black_skip_string_normalization in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,9 @@ Preferences -> Package Settings -> sublack -> settings :
 * black_default_encoding:
 	Should not be changed. Only needed on some OSX platforms.
 
+* black_skip_string_normalization:
+	Don't normalize string quotes or prefixes. Default = false.
+
 
 Project settings
 *******************


### PR DESCRIPTION
I didn't find this option documented so I was about to create a Pull Request to add it. 

As I read through the code I noticed this function actually already existed. 

Here's a PR to add this feature to the README file.