### PR TITLE
Add special handling of .pyi (stub) files

### DIFF
--- a/sublack.py
+++ b/sublack.py
@@ -119,6 +119,10 @@ class Black:
         if self.config.get("black_skip_string_normalization"):
             cmd.append("--skip-string-normalization")
 
+        filename = self.view.file_name()
+        if filename and filename.endswith(".pyi"):
+            cmd.append("--pyi")
+
         # extra args
         if extra:
             cmd.extend(extra)


### PR DESCRIPTION
`.pyi` are formatted more dense. See https://github.com/ambv/black#typing-stub-files

For stdin mode, we should give black a hint via the `--pyi` flag.