### PR TITLE
Hide black commands if not applicable

### DIFF
--- a/sublack.py
+++ b/sublack.py
@@ -268,6 +268,8 @@ class BlackFileCommand(sublime_plugin.TextCommand):
     def is_enabled(self):
         return is_python(self.view)
 
+    is_visible = is_enabled
+
     def run(self, edit):
         if get_settings(self.view)["black_debug_on"]:
             print("[SUBLACK] : run black_file")
@@ -281,6 +283,8 @@ class BlackDiffCommand(sublime_plugin.TextCommand):
 
     def is_enabled(self):
         return is_python(self.view)
+
+    is_visible = is_enabled
 
     def run(self, edit):
         if get_settings(self.view)["black_debug_on"]:


### PR DESCRIPTION
Hides the sublack commands from the context menu on non python files.