### PR TITLE
Provide a command to toggle black_on_save per view

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -2,9 +2,12 @@
     {
         "caption": "Sublack: Format file",
         "command": "black_file"
-    },    
+    },
     {
         "caption": "Sublack: Diff file",
         "command": "black_diff"
+    },
+    {
+        "command": "black_toggle_black_on_save"
     },
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -2,9 +2,13 @@
     {
         "caption": "Sublack: Format file",
         "command": "black_file"
-    },    
+    },
     {
         "caption": "Sublack: Diff file",
         "command": "black_diff"
+    },
+    {
+        "caption": "Sublack: Toggle black on save for current view",
+        "command": "black_toggle_black_on_save"
     },
 ]


### PR DESCRIPTION
Registers a command in the Command Palette and Context Menu to quickly enable/disable black_on_save. This is probably the easiest way UI-wise to disable format on save on demand. 

Otherwise, feel free to shred it. I just wanted to try it, and was too lazy to open an issue first. (Exclusion lists etc. are usually less naive, but maybe this is just enough, and the UI is easy to reach.)