### PR TITLE
Change parameter black_blackd_server_port

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,7 @@ Sublack specifics options
 * black_blackd_server_host:
     default = "localhost",
 
-* black_blackd_server_port:
+* black_blackd_port:
     default = "45484"
 
 * black_blackd_autostart:


### PR DESCRIPTION
The blackd server port is documented as `black_blackd_server_port` when the correct one is `black_blackd_port`.